### PR TITLE
✨ Start-prod without livereload

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "compile": "browserify -d src/index.js -s osrm > bundle.raw.js && uglifyjs bundle.raw.js -c -m --source-map=bundle.js.map -o bundle.js",
     "build": "npm run replace && npm run compile && cp node_modules/leaflet/dist/leaflet.css css/leaflet.css",
     "start-index": "budo src/index.js --serve=bundle.js --live -d | bistre",
+    "start-index-prod": "budo src/index.js --serve=bundle.js -d | bistre",
     "start": "npm run build && npm run start-index",
+    "start-prod": "npm run build && npm run start-index-prod",
     "prepub": "npm run build"
   },
   "repository": {


### PR DESCRIPTION
:sparkles: Start-prod without livereload fix #278

Using this, the container can be used simply in production by setting command to run:
```
docker run -p 9966:9966 osrm/osrm-frontend npm run start-prod
```